### PR TITLE
Add support for MPI.jl_v0.20 and fix openmpi bugs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
-MPI = "0.19"
+MPI = "0.20"
 OffsetArrays = "1.10"
 julia = "1.6"
 EllipsisNotation = "1.3"

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -11,9 +11,9 @@ function globalsum(A::MPIHaloArray{T,N}; root=0, broadcast=false) where {T,N}
     localsum = sum(domainview(A))
 
     if broadcast
-        globalsum = MPI.Allreduce(localsum, MPI.MPI_SUM, A.topology.comm)
+        globalsum = MPI.Allreduce(localsum, MPI.SUM, A.topology.comm)
     else
-        globalsum = MPI.Reduce(localsum, MPI.MPI_SUM, root, A.topology.comm)
+        globalsum = MPI.Reduce(localsum, MPI.SUM, root, A.topology.comm)
     end
 
     globalsum
@@ -31,9 +31,9 @@ function globalmax(A::MPIHaloArray{T,N}; root=0, broadcast=false) where {T,N}
     localmax = maximum(domainview(A))
 
     if broadcast
-        globalmax = MPI.Allreduce(localmax, MPI.MPI_MAX, A.topology.comm)
+        globalmax = MPI.Allreduce(localmax, MPI.MAX, A.topology.comm)
     else
-        globalmax = MPI.Reduce(localmax, MPI.MPI_MAX, root, A.topology.comm)
+        globalmax = MPI.Reduce(localmax, MPI.MAX, root, A.topology.comm)
     end
     globalmax
 end
@@ -50,9 +50,9 @@ function globalmin(A::MPIHaloArray{T,N}; root=0, broadcast=false) where {T,N}
     localmin = minimum(domainview(A))
 
     if broadcast
-        globalmin = MPI.Allreduce(localmin, MPI.MPI_MIN, A.topology.comm)
+        globalmin = MPI.Allreduce(localmin, MPI.MIN, A.topology.comm)
     else
-        globalmin = MPI.Reduce(localmin, MPI.MPI_MIN, root, A.topology.comm)
+        globalmin = MPI.Reduce(localmin, MPI.MIN, root, A.topology.comm)
     end
     globalmin
 end

--- a/src/topology.jl
+++ b/src/topology.jl
@@ -119,7 +119,7 @@ function CartesianTopology(comm::MPI.Comm, dims::NTuple{N, Int}, periodicity::NT
     periodicity_tuple = vec_to_ntuple(periodicity)
     topo_dim = length(dims)
 
-    neighbors = OffsetArray(-ones(Int8,3,3,3), -1:1, -1:1, -1:1)
+    neighbors = OffsetArray(Int(MPI.API.MPI_PROC_NULL[]) * ones(Int8,3,3,3), -1:1, -1:1, -1:1)
 
     # MPI convention is (k, j, i), or (z, y, x) which is annoying
     if topo_dim == 1
@@ -264,7 +264,7 @@ function coord_to_rank(comm, dims, periods, coords)
     if isvalid
         rank = MPI.Cart_rank(comm, mpi_coords)
     else
-        rank = -1
+        rank = Int(MPI.API.MPI_PROC_NULL[])
     end
     rank
 end

--- a/test/unit/run_unittests.jl
+++ b/test/unit/run_unittests.jl
@@ -30,7 +30,7 @@ end
     file, nprocs = f
     mpiexec() do cmd
         # e.g. run `mpiexec -n 4 julia test_somthing.jl`
-        run(`$cmd -host localhost -n $nprocs $(Base.julia_cmd()) $(joinpath(testdir, file))`)
+        run(`$cmd -n $nprocs $(Base.julia_cmd()) $(joinpath(testdir, file))`)
         @test true
     end
 end

--- a/test/unit/test_topology_1d.jl
+++ b/test/unit/test_topology_1d.jl
@@ -8,6 +8,9 @@ const comm = MPI.COMM_WORLD
 const rank = MPI.Comm_rank(comm)
 const nprocs = MPI.Comm_size(comm)
 
+# Different MPI flavors have different NULL int conventions.
+const NULL_PROC = Int(MPI.API.MPI_PROC_NULL[])
+
 const ilo = -1
 const ihi = +1
 const i = 0
@@ -46,7 +49,7 @@ function test_16x1_topology_no_periodic()
 
     #  0  1  2  3  4  5  6  7  8  9  10  11  12  13  14  15
     if P.rank == 0 # test at edge
-        @test ilo_neighbor(P) == -1
+        @test ilo_neighbor(P) == NULL_PROC
         @test ihi_neighbor(P) == 1
 
     elseif P.rank == 5 # test a middle node
@@ -59,9 +62,9 @@ function test_4x4_topology_no_periodic()
     P = CartesianTopology(comm, [4,4], [false,false])
 
     if P.rank == 0 # test at edge
-        @test ilo_neighbor(P) == -1
+        @test ilo_neighbor(P) == NULL_PROC
         @test ihi_neighbor(P) == 1
-        @test jlo_neighbor(P) == -1
+        @test jlo_neighbor(P) == NULL_PROC
         @test jhi_neighbor(P) == 4
 
     elseif P.rank == 5 # test a middle node

--- a/test/unit/test_topology_2d.jl
+++ b/test/unit/test_topology_2d.jl
@@ -7,6 +7,9 @@ const comm = MPI.COMM_WORLD
 const rank = MPI.Comm_rank(comm)
 const nprocs = MPI.Comm_size(comm)
 
+# Different MPI flavors have different NULL int conventions.
+const NULL_PROC = Int(MPI.API.MPI_PROC_NULL[])
+
 const ilo = -1
 const ihi = +1
 const jlo = -1
@@ -23,17 +26,17 @@ function test_4x4_topology_all_periodic()
     P = CartesianTopology(comm, [4,4], [true, true])
 
     # Layout for 4x4 domain; rank and (coords) are shown
-    
-    
+
+
     #   +----- (i)
     #   |
-    #   | 
+    #   |
     #   |  (j)
 
     #      ilo --> ihi
     #   |-------|-------|-------|-------|   jlo
     #   |       |       |       |       |    |
-    #   |   0   |   1   |   2   |   3   |    ↓   
+    #   |   0   |   1   |   2   |   3   |    ↓
     #   | (0,0) | (0,1) | (0,2) | (0,3) |   jhi
     #   |-------|-------|-------|-------|
     #   |       |       |       |       |
@@ -54,39 +57,39 @@ function test_4x4_topology_all_periodic()
         @test ihi_neighbor(P) == 1
         @test jlo_neighbor(P) == 12
         @test jhi_neighbor(P) == 4
-        @test klo_neighbor(P) == -1
-        @test khi_neighbor(P) == -1
+        @test klo_neighbor(P) == NULL_PROC
+        @test khi_neighbor(P) == NULL_PROC
 
         @test neighbor(P, ihi, jhi) == 5
-        @test neighbor(P, ihi, jlo) == 13  
-        @test neighbor(P, ilo, jhi) == 7  
-        @test neighbor(P, ilo, jlo) == 15  
+        @test neighbor(P, ihi, jlo) == 13
+        @test neighbor(P, ilo, jhi) == 7
+        @test neighbor(P, ilo, jlo) == 15
 
     elseif P.rank == 5 # test a middle node
         @test ilo_neighbor(P) == 4
         @test ihi_neighbor(P) == 6
         @test jlo_neighbor(P) == 1
         @test jhi_neighbor(P) == 9
-        @test klo_neighbor(P) == -1
-        @test khi_neighbor(P) == -1
-        
+        @test klo_neighbor(P) == NULL_PROC
+        @test khi_neighbor(P) == NULL_PROC
+
         @test neighbor(P, ihi, jhi) == 10
         @test neighbor(P, ihi, jlo) == 2
-        @test neighbor(P, ilo, jhi) == 8  
-        @test neighbor(P, ilo, jlo) == 0  
+        @test neighbor(P, ilo, jhi) == 8
+        @test neighbor(P, ilo, jlo) == 0
 
     elseif P.rank == 13 # test one on the edge
         @test ilo_neighbor(P) == 12
         @test ihi_neighbor(P) == 14
         @test jlo_neighbor(P) == 9
         @test jhi_neighbor(P) == 1
-        @test klo_neighbor(P) == -1
-        @test khi_neighbor(P) == -1
-        
+        @test klo_neighbor(P) == NULL_PROC
+        @test khi_neighbor(P) == NULL_PROC
+
         @test neighbor(P, ihi, jhi) == 2
         @test neighbor(P, ihi, jlo) == 10
         @test neighbor(P, ilo, jhi) == 0
-        @test neighbor(P, ilo, jlo) == 8  
+        @test neighbor(P, ilo, jlo) == 8
     end
 end
 
@@ -94,17 +97,17 @@ function test_4x4_topology_no_periodic()
     P = CartesianTopology(comm, [4,4], [false, false])
 
     # Layout for 4x4 domain; rank and (coords) are shown
-    
-    
+
+
     #   +----- (i)
     #   |
-    #   | 
+    #   |
     #   |  (j)
 
     #      ilo --> ihi
     #   |-------|-------|-------|-------|   jlo
     #   |       |       |       |       |    |
-    #   |   0   |   1   |   2   |   3   |    ↓   
+    #   |   0   |   1   |   2   |   3   |    ↓
     #   | (0,0) | (0,1) | (0,2) | (0,3) |   jhi
     #   |-------|-------|-------|-------|
     #   |       |       |       |       |
@@ -121,43 +124,43 @@ function test_4x4_topology_no_periodic()
     #   |-------|-------|-------|-------|
 
     if P.rank == 0 # test a corner
-        @test ilo_neighbor(P) == -1
+        @test ilo_neighbor(P) == NULL_PROC
         @test ihi_neighbor(P) == 1
-        @test jlo_neighbor(P) == -1
+        @test jlo_neighbor(P) == NULL_PROC
         @test jhi_neighbor(P) == 4
-        @test klo_neighbor(P) == -1
-        @test khi_neighbor(P) == -1
+        @test klo_neighbor(P) == NULL_PROC
+        @test khi_neighbor(P) == NULL_PROC
 
         @test neighbor(P, ihi, jhi) == 5
-        @test neighbor(P, ihi, jlo) == -1  
-        @test neighbor(P, ilo, jhi) == -1 
-        @test neighbor(P, ilo, jlo) == -1  
+        @test neighbor(P, ihi, jlo) == NULL_PROC
+        @test neighbor(P, ilo, jhi) == NULL_PROC
+        @test neighbor(P, ilo, jlo) == NULL_PROC
 
     elseif P.rank == 5 # test a middle node
         @test ilo_neighbor(P) == 4
         @test ihi_neighbor(P) == 6
         @test jlo_neighbor(P) == 1
         @test jhi_neighbor(P) == 9
-        @test klo_neighbor(P) == -1
-        @test khi_neighbor(P) == -1
-        
+        @test klo_neighbor(P) == NULL_PROC
+        @test khi_neighbor(P) == NULL_PROC
+
         @test neighbor(P, ihi, jhi) == 10
         @test neighbor(P, ihi, jlo) == 2
-        @test neighbor(P, ilo, jhi) == 8  
-        @test neighbor(P, ilo, jlo) == 0  
+        @test neighbor(P, ilo, jhi) == 8
+        @test neighbor(P, ilo, jlo) == 0
 
     elseif P.rank == 13 # test one on the edge
         @test ilo_neighbor(P) == 12
         @test ihi_neighbor(P) == 14
         @test jlo_neighbor(P) == 9
-        @test jhi_neighbor(P) == -1
-        @test klo_neighbor(P) == -1
-        @test khi_neighbor(P) == -1
-        
-        @test neighbor(P, ihi, jhi) == -1
+        @test jhi_neighbor(P) == NULL_PROC
+        @test klo_neighbor(P) == NULL_PROC
+        @test khi_neighbor(P) == NULL_PROC
+
+        @test neighbor(P, ihi, jhi) == NULL_PROC
         @test neighbor(P, ihi, jlo) == 10
-        @test neighbor(P, ilo, jhi) == -1
-        @test neighbor(P, ilo, jlo) == 8  
+        @test neighbor(P, ilo, jhi) == NULL_PROC
+        @test neighbor(P, ilo, jlo) == 8
     end
 end
 

--- a/test/unit/test_topology_3d.jl
+++ b/test/unit/test_topology_3d.jl
@@ -7,6 +7,10 @@ MPI.Init()
 const comm = MPI.COMM_WORLD
 const rank = MPI.Comm_rank(comm)
 const nprocs = MPI.Comm_size(comm)
+
+# Different MPI flavors have different NULL int conventions.
+const NULL_PROC = Int(MPI.API.MPI_PROC_NULL[])
+
 const ilo = -1
 const ihi = +1
 const jlo = -1
@@ -109,35 +113,35 @@ function test_2x2x4_topology_no_periodic()
 
     if P.rank == 0
         # klo
-        @test neighbor(P, ilo, jlo, klo) == -1
-        @test neighbor(P, i  , jlo, klo) == -1
-        @test neighbor(P, ihi, jlo, klo) == -1
-        @test neighbor(P, ilo, j  , klo) == -1
-        @test neighbor(P, ihi, j  , klo) == -1
-        @test neighbor(P, ilo, jhi, klo) == -1
-        @test neighbor(P, i  , jhi, klo) == -1
-        @test neighbor(P, ihi, jhi, klo) == -1
+        @test neighbor(P, ilo, jlo, klo) == NULL_PROC
+        @test neighbor(P, i  , jlo, klo) == NULL_PROC
+        @test neighbor(P, ihi, jlo, klo) == NULL_PROC
+        @test neighbor(P, ilo, j  , klo) == NULL_PROC
+        @test neighbor(P, ihi, j  , klo) == NULL_PROC
+        @test neighbor(P, ilo, jhi, klo) == NULL_PROC
+        @test neighbor(P, i  , jhi, klo) == NULL_PROC
+        @test neighbor(P, ihi, jhi, klo) == NULL_PROC
 
         # k
-        @test ilo_neighbor(P) == -1
+        @test ilo_neighbor(P) == NULL_PROC
         @test ihi_neighbor(P) ==  1
-        @test jlo_neighbor(P) == -1
+        @test jlo_neighbor(P) == NULL_PROC
         @test jhi_neighbor(P) ==  2
-        @test klo_neighbor(P) == -1
+        @test klo_neighbor(P) == NULL_PROC
         @test khi_neighbor(P) ==  4
 
         @test neighbor(P, ihi, jhi, k) == 3
-        @test neighbor(P, ihi, jlo, k) == -1
-        @test neighbor(P, ilo, jlo, k) == -1
-        @test neighbor(P, ilo, jhi, k) == -1
+        @test neighbor(P, ihi, jlo, k) == NULL_PROC
+        @test neighbor(P, ilo, jlo, k) == NULL_PROC
+        @test neighbor(P, ilo, jhi, k) == NULL_PROC
 
         # khi
-        @test neighbor(P, ilo, jlo, khi) == -1
-        @test neighbor(P, i  , jlo, khi) == -1
-        @test neighbor(P, ihi, jlo, khi) == -1
-        @test neighbor(P, ilo, j  , khi) == -1
+        @test neighbor(P, ilo, jlo, khi) == NULL_PROC
+        @test neighbor(P, i  , jlo, khi) == NULL_PROC
+        @test neighbor(P, ihi, jlo, khi) == NULL_PROC
+        @test neighbor(P, ilo, j  , khi) == NULL_PROC
         @test neighbor(P, ihi, j  , khi) == 5
-        @test neighbor(P, ilo, jhi, khi) == -1
+        @test neighbor(P, ilo, jhi, khi) == NULL_PROC
         @test neighbor(P, i  , jhi, khi) == 6
         @test neighbor(P, ihi, jhi, khi) == 7
     end


### PR DESCRIPTION
There were some breaking API changes with `MPI.jl` v0.20. This PR resolves those.

In addition, this generalizes the cartesian topology structure to properly work with `openMPI`, and not just `MPICH`/`IntelMPI`. Specifically, the `NULL_PROC=-1` convention is *not* part of the MPI standard. So rather than hardcode in `-1`, this calls the API-level `MPI_PROC_NULL` and uses that. This was particularly problematic, as the current codebase used a "mix" of hardcoded values and relying on what was returned by `Cart_shift()`, which is `MPI_PROC_NULL` when no proc exists. Now the convention is consistent.

There are some minor formatting changes throughout (e.g. proper newlines).

Finally, most of `topology.jl` could actually be implemented with a simple call to `mpi_cart_rank`. Indeed it looks like you are using `MPI_Cart_shift` to slowly build up a table to perform what `mpi_cart_rank` natively does anyway (which is ironic, as `MPI_Cart_shift` actually *wraps* around `mpi_cart_rank` to simplify the scope). Using `mpi_cart_rank` directly means you no longer need to build up a table on each proc (which I see is difficult for the corners when all you are using is `MPI_Cart_shift`) and can just call that function directly (one can wrap it, of course, to make it work well with `neighbors`, `jhi_neighbor`, etc) But I'll leave this to a future PR.